### PR TITLE
[Fix] update relative path for vundle to fix issue when loading vundle

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -4,7 +4,7 @@ set nocompatible
 filetype off
 
 " Use Vundle to manage plugins
-set rtp+=~/.vim/bundle/Vundle.vim
+set rtp+=~/.vim/bundle/vundle
 call vundle#begin()
 source ~/.vim/vimrc.bundles
 call vundle#end()


### PR DESCRIPTION
It seems vundle repository changes its directory structure. Currently, after git cloning vundle repo, the vundle folder is under the following file path:

* bundle -> vundle